### PR TITLE
update the cloudstor out-of-date installation packages 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -141,7 +141,7 @@ jobs:
     - name: Install DAKOTA
       run: |
         export PKGN=dakota-${{ env.DAKVER }}-${{ matrix.os }}-x86_64-jp
-        export DAKURL="https://cloudstor.aarnet.edu.au/plus/s/TaoO6XnrGRiwoiC/download?path=%2F&files=$PKGN.tar.gz"
+        export DAKURL="https://github.com/anustg/installation-packages/releases/download/omc-dakota-solstice-installation/$PKGN.tar.gz"
         sudo tar zxv --strip-components=3 -C /usr/local < <(wget "$DAKURL" -q -O-)
         export PATH=$PATH:/usr/local/bin    # needed for Ubuntu 18.04
         export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib  # needed for 18.04

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -109,7 +109,7 @@ jobs:
       run: |
         sudo apt install libpolyclipping-dev libtbb-dev libyaml-dev  libgomp1
         export UBVER=`lsb_release -cs`
-        export SOLSTICEURL="https://cloudstor.aarnet.edu.au/plus/s/TaoO6XnrGRiwoiC/download?path=%2F&files=solstice-${SOLSTICEVER}-x86_64-$UBVER.tar.gz"
+        export SOLSTICEURL="https://github.com/anustg/installation-packages/releases/download/omc-dakota-solstice-installation/solstice-${SOLSTICEVER}-x86_64-$UBVER.tar.gz"
         sudo tar zxv --strip-components=3 -C /usr/local < <(wget "$SOLSTICEURL" -q -O-)
         echo "CHECK SOLSTICE DEPS"
         export PATH=$PATH:/usr/local/bin

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -56,7 +56,7 @@ jobs:
     - name: Install OpenModelica 1.19
       run: |
         mkdir ~/omc-repo && cd ~/omc-repo
-        wget -qO- "https://cloudstor.aarnet.edu.au/plus/s/ex7S4y8QzlDjQCY/download" | bsdtar -xvf-
+        wget -qO- "https://github.com/anustg/installation-packages/releases/download/omc-dakota-solstice-installation/omc-mingw64.zip" | bsdtar -xvf-
         echo -e "[openmodelica]\nSigLevel=Never\nServer=file://$PWD" >> /etc/pacman.conf
         pacboy -Sy --noconfirm omc:p openmodelica-msl:p
         echo "REVIEW INSTALLED OMC VERSION..."


### PR DESCRIPTION
by 'tag release' function from anustg github repository